### PR TITLE
Fix Terraform output parsing in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_wrapper: false
 
       - name: Terraform Init
         run: terraform -chdir=infra init
@@ -40,7 +42,7 @@ jobs:
       - name: Get Lambda Function Name
         id: lambda-name
         run: |
-          LAMBDA_NAME=$(terraform -chdir=infra output -raw lambda_function_name)
+          LAMBDA_NAME=$(terraform -chdir=infra output -json lambda_function_name | jq -r .)
           echo "lambda_name=$LAMBDA_NAME" >> $GITHUB_OUTPUT
 
       - name: Update Lambda Function


### PR DESCRIPTION
The fix:

Disabled Terraform wrapper that adds debug output

Used JSON output with jq to cleanly extract the function name

